### PR TITLE
Article header photo fix

### DIFF
--- a/templates/article.ejs
+++ b/templates/article.ejs
@@ -47,8 +47,8 @@
 
   <header
     style="background-image: linear-gradient(rgba(0,0,0,0),rgba(0,0,0,0.5))<% if (typeof articleHeaderPhoto !== 'undefined') { %>,url(<%= articleHeaderPhoto %>)<% } %>;"
-    data-68="background-image: linear-gradient(rgba(0,0,0,0),rgba(0,0,0,0.5))<% if (typeof articleHeaderPhoto !== 'undefined') { %>,url(<%= articleHeaderPhoto %>)<% } %>; transform: translate3d(0px,0%,0px)"
-    data-500="background-image: linear-gradient(rgba(0,0,0,0.8),rgba(0,0,0,0.8))<% if (typeof articleHeaderPhoto !== 'undefined') { %>,url(<%= articleHeaderPhoto %>)<% } %>; transform: translate3d(0px,100%,0px)">
+    data-68="transform: translate3d(0px,0%,0px)"
+    data-500="transform: translate3d(0px,100%,0px)">
     <% if (typeof articleCategory !== 'undefined') { %>
     <div class="category"><%= articleCategory %></div>
     <% } %>


### PR DESCRIPTION
Fixes missing article header photos
- Something in the skrollr library is parsing 0s in and out of url's in skrollr 'data' tags incorrectly. Removing the background-image from the skrollr data tags in the header keeps skrollr from trying to parse and update it. It does mean the gradient won't be able to adjust along with the scrolling, but that's ok.
