### PR TITLE
Daily Shine for the web

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 example-pages/example-advice-home.html
 example-pages/example-article.html
 example-pages/example-author.html
+example-pages/example-dailyshine.html

--- a/circle.yml
+++ b/circle.yml
@@ -21,12 +21,12 @@ deployment:
   production:
     branch: releases
     commands:
-      - ./deploy.sh --bucket=advice.shinetext.com
+      - ./deploy.sh --bucket=advice.shinetext.com --dailyshine_s3=daily.shinetext.com
   dev:
     branch: master
     commands:
-      - ./deploy.sh --bucket=st-webcontent-dev
+      - ./deploy.sh --bucket=st-webcontent-dev --dailyshine_s3=st-daily-dev
   jon:
     branch: jon
     commands:
-      - ./deploy.sh --bucket=st-webcontent-jon
+      - ./deploy.sh --bucket=st-webcontent-jon --dailyshine_s3=st-daily-jon

--- a/compile.sh
+++ b/compile.sh
@@ -1,2 +1,6 @@
 lessc styles/importer.less _tmp/styles.css
-echo "Compile finished. Wrote to file: _tmp/styles.css"
+echo "Wrote to file: _tmp/styles.css"
+
+lessc styles/dailyshine/importer.less _tmp/dailyshine.css
+echo "Wrote to file: _tmp/dailyshine.css"
+echo "Finished compiling styles"

--- a/deploy-scripts/compile-dailyshine.js
+++ b/deploy-scripts/compile-dailyshine.js
@@ -1,0 +1,31 @@
+/**
+ * A script to be run on deployment.
+ *
+ * Compiles the advice homepage template and writes to a file that should then
+ * be copied over to its appropriate S3 bucket.
+ */
+
+'use strict';
+
+const ejs = require('ejs');
+const fs = require('fs');
+
+const templateFilename = './templates/daily-shine.ejs';
+const outputFilename = './_tmp/daily-shine.html';
+
+// Read the template file
+const template = fs.readFileSync(templateFilename, 'utf-8');
+
+// Template data
+const data = {
+  css: 'dailyshine.css',
+  jsPath: '',
+  contentBaseUrl: '/_data/',
+  photonBaseUrl: process.env.PHOTON_BASE_URL || '',
+};
+
+// Render and write to file
+const output = ejs.render(template, data, null);
+fs.writeFileSync(outputFilename, output);
+
+console.log(`wrote to file: ${outputFilename}`);

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,26 +6,34 @@ mkdir _tmp
 
 ## Get the bucket name from the arguments
 BUCKET=""
+DAILYSHINE_S3_BUCKET=""
 for i in "$@"
 do
   case $i in
-    -b=*|--bucket=*)
+    --bucket=*)
     BUCKET="${i#*=}"
+    shift
+    ;;
+    --dailyshine_s3=*)
+    DAILYSHINE_S3_BUCKET="${i#*=}"
     shift
     ;;
   esac
 done
 
-echo $BUCKET
-if [ "$BUCKET" = "" ]; then
-  echo "No bucket name specified. Usage: $ ./deploy.sh --bucket=the-bucket-name"
+if [ "$BUCKET" = "" ] || [ "$DAILYSHINE_S3_BUCKET" = "" ]; then
+  echo "Missing a bucket name. Usage: $ ./deploy.sh --bucket=bucket-name --dailyshine_s3=other-bucket"
   exit
 else
-  echo "Using bucket: ${BUCKET}"
+  echo "Using buckets -- content: ${BUCKET} / daily: ${DAILYSHINE_S3_BUCKET}"
 fi
 
 ## Compile the advice-home template
 node deploy-scripts/compile-advice-home.js
+
+## Compile the daily shine template
+PHOTON_BASE_URL=$PHOTON_BASE_URL \
+  node deploy-scripts/compile-dailyshine.js
 
 ## Deploy to S3
 aws s3 cp _tmp/styles.css "s3://$BUCKET/styles.css"
@@ -33,5 +41,8 @@ aws s3 cp _tmp/advice-home.html "s3://$BUCKET/index.html" --content-type="text/h
 aws s3 cp js/ "s3://$BUCKET/js/" --recursive
 aws s3 cp templates/article.ejs "s3://$BUCKET/templates/article.ejs" --content-type="text/plain"
 aws s3 cp templates/author.ejs "s3://$BUCKET/templates/author.ejs" --content-type="text/plain"
+
+## Deploy the daily shine render to its own bucket
+aws s3 cp _tmp/daily-shine.html "s3://$DAILYSHINE_S3_BUCKET/index.html" --content-type="text/html"
 
 echo "Compile & deploy to S3 complete"

--- a/deploy.sh
+++ b/deploy.sh
@@ -21,28 +21,35 @@ do
   esac
 done
 
-if [ "$BUCKET" = "" ] || [ "$DAILYSHINE_S3_BUCKET" = "" ]; then
-  echo "Missing a bucket name. Usage: $ ./deploy.sh --bucket=bucket-name --dailyshine_s3=other-bucket"
-  exit
+if [ "$BUCKET" = "" ]; then
+  echo "No content bucket specified. Usage: $ ./deploy.sh --bucket=bucket-name"
 else
-  echo "Using buckets -- content: ${BUCKET} / daily: ${DAILYSHINE_S3_BUCKET}"
+  echo "Deploying to content bucket: ${BUCKET}"
+
+  ## Compile the advice-home template
+  node deploy-scripts/compile-advice-home.js
+
+  ## Deploy to S3
+  aws s3 cp _tmp/styles.css "s3://$BUCKET/styles.css"
+  aws s3 cp _tmp/advice-home.html "s3://$BUCKET/index.html" --content-type="text/html"
+  aws s3 cp js/ "s3://$BUCKET/js/" --recursive
+  aws s3 cp templates/article.ejs "s3://$BUCKET/templates/article.ejs" --content-type="text/plain"
+  aws s3 cp templates/author.ejs "s3://$BUCKET/templates/author.ejs" --content-type="text/plain"
 fi
 
-## Compile the advice-home template
-node deploy-scripts/compile-advice-home.js
+if [ "$DAILYSHINE_S3_BUCKET" = "" ]; then
+  echo "No daily shine bucket specified. Usage: $ ./deploy.sh --dailyshine_s3=other-bucket"
+else
+  echo "Deploying to daily shine bucket: ${DAILYSHINE_S3_BUCKET}"
 
-## Compile the daily shine template
-PHOTON_BASE_URL=$PHOTON_BASE_URL \
-  node deploy-scripts/compile-dailyshine.js
+  ## Compile the daily shine template
+  PHOTON_BASE_URL=$PHOTON_BASE_URL \
+    node deploy-scripts/compile-dailyshine.js
 
-## Deploy to S3
-aws s3 cp _tmp/styles.css "s3://$BUCKET/styles.css"
-aws s3 cp _tmp/advice-home.html "s3://$BUCKET/index.html" --content-type="text/html"
-aws s3 cp js/ "s3://$BUCKET/js/" --recursive
-aws s3 cp templates/article.ejs "s3://$BUCKET/templates/article.ejs" --content-type="text/plain"
-aws s3 cp templates/author.ejs "s3://$BUCKET/templates/author.ejs" --content-type="text/plain"
-
-## Deploy the daily shine render to its own bucket
-aws s3 cp _tmp/daily-shine.html "s3://$DAILYSHINE_S3_BUCKET/index.html" --content-type="text/html"
+  ## Deploy the daily shine to its own bucket
+  aws s3 cp _tmp/dailyshine.css "s3://$DAILYSHINE_S3_BUCKET/dailyshine.css"
+  aws s3 cp js/ "s3://$DAILYSHINE_S3_BUCKET/js/" --recursive
+  aws s3 cp _tmp/daily-shine.html "s3://$DAILYSHINE_S3_BUCKET/index.html" --content-type="text/html"
+fi
 
 echo "Compile & deploy to S3 complete"

--- a/example-pages/compile-ejs.js
+++ b/example-pages/compile-ejs.js
@@ -21,6 +21,7 @@ if (articleObj.author && articleObj.author.bio) {
 const articleData = {
   articleAuthor: articleObj.author,
   articleBody: marked(articleObj.body['en-US']),
+  articleCategory: articleObj.category ? articleObj.category['en-US'] :  undefined,
   articleDate: formatDisplayDate(new Date(articleObj.date['en-US'])),
   articleDescription: articleObj.description ? articleObj.description['en-US'] : undefined,
   articleHeaderPhoto: articleObj.headerPhoto ? `https:${articleObj.headerPhoto.file.url}` : undefined,
@@ -64,6 +65,18 @@ const adviceData = {
 };
 
 compile('../templates/advice-home.ejs', 'example-advice-home.html', adviceData);
+
+/////
+// Compile example daily web template
+/////
+const dailyData = {
+  css: '../_tmp/dailyshine.css',
+  jsPath: '..',
+
+  contentBaseUrl: process.env.DAILYSHINE_CONTENT_BASE_URL,
+};
+
+compile('../templates/daily-shine.ejs', 'example-dailyshine.html', dailyData);
 
 process.exit();
 

--- a/js/dailyshine.js
+++ b/js/dailyshine.js
@@ -155,6 +155,9 @@
       if (data.media) {
         template = $('#template-mt-media').html();
       }
+      else if (data.linkTitle && data.linkUrl) {
+        template = $('#template-mt-link').html();
+      }
       else {
         template = $('#template-mt').html();
       }
@@ -238,6 +241,7 @@
 
     // @todo Trigger any animation that should happen here before displaying
     // the next message
+    element.removeClass('-active');
     element.addClass('-clicked');
     element.off('click');
 

--- a/js/dailyshine.js
+++ b/js/dailyshine.js
@@ -37,7 +37,7 @@
    */
   function loadUser() {
     var url;
-    var code = getUserCode();
+    var code = getParameter('r');
 
     if (code && code.length > 0) {
       url = photonBaseUrl + 'users?referralCode=' + code;
@@ -48,6 +48,14 @@
         dataType: 'json',
         success: function(data) {
           userData = data;
+
+          loadDailyShine();
+        },
+        error: function(jqXHR, textStatus, errorThrown) {
+          console.error({
+            status: textStatus,
+            error: errorThrown,
+          });
 
           loadDailyShine();
         },
@@ -82,10 +90,10 @@
     $.get({
       url: url,
       data: null,
+      dataType: 'json',
       success: function(data) {
         displayMT(data.starterMessage['en-US'].fields);
       },
-      dataType: 'json',
     });
   }
 
@@ -325,28 +333,6 @@
   }
 
   /**
-   * Helper function for extracting the user's referral code to use their
-   * identifier to get more info.
-   *
-   * @return string
-   */
-  function getUserCode() {
-    var code;
-    var path;
-
-    // Expecting to be able to extract the code from the URL
-    if (getParameter('referralCode')) {
-      code = getParameter('referralCode');
-    }
-    else {
-      path = window.location.pathname.split('/');
-      code = path.indexOf(path.length - 1);
-    }
-
-    return code;
-  }
-
-  /**
    * Logic to run once the end of the messaging flow has been reached.
    */
   function onMessagesFinished() {
@@ -380,7 +366,7 @@
     data = {
       // Used for the share link
       shareLink: 'http://' + window.location.hostname + '?date=' + dateQuery,
-      showCTA: getUserCode() ? false : true,
+      showCTA: getParameter('r') ? false : true,
       // Randomly select an end message
       endMessage: END_MESSAGES[Math.floor(Math.random() * END_MESSAGES.length)],
     };
@@ -390,6 +376,16 @@
     element.hide()
         .delay(DELAY_MT_DISPLAY + DELAY_MO_DISPLAY)
         .fadeIn(DISPLAY_ANIM_DURATION);
+
+    // Send GA event
+    if (ga) {
+      ga('send', {
+        hitType: 'event',
+        eventCategory: 'end',
+        eventAction: 'reached',
+        eventLabel: dateQuery,
+      });
+    }
   }
 
 })();

--- a/js/dailyshine.js
+++ b/js/dailyshine.js
@@ -6,7 +6,7 @@
   var DELAY_MT_DISPLAY = 500;
 
   // Delay before showing the MO options
-  var DELAY_MO_DISPLAY = 1000;
+  var DELAY_MO_DISPLAY = 1250;
 
   // Duration of display animations
   var DISPLAY_ANIM_DURATION = 750;
@@ -90,40 +90,51 @@
    * @param content Content of the message to display
    */
   function displayMT(content) {
+    var body;
     var data;
     var html;
-    var currMessage;
-    var currMessages;
-
+    var messages;
     var nextMessages;
     var template;
     var i;
 
     template = $('#template-mt').html();
 
+    // Merge user data into the message
+    body = mergeData(localized(content.body));
 
-    currMessage = mergeData(localized(content.body));
-    currMessages = currMessage.split('\n');
+    // Split message by new line so each message gets its own bubble
+    messages = body.split('\n');
 
     // Remove empty entries
-    for (i = currMessages.length - 1; i >= 0; i--) {
-      if (currMessages[i].length == 0 ||
-          (currMessages[i].length == 1 && currMessages[i].charCodeAt(0) == 13)) {
-        currMessages.splice(i, 1);
+    for (i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].length == 0 ||
+          (messages[i].length == 1 && messages[i].charCodeAt(0) == 13)) {
+        messages.splice(i, 1);
       }
     }
 
-    for (i = 0; i < currMessages.length; i++) {
-      data = {
-        message: currMessages[i].trim(),
-        linkTitle: undefined,
-        linkUrl: undefined,
-      };
+    // Display the media asset first if there is one
+    if (content.media) {
+      messages.unshift({
+        media: content.media.fields.file.url,
+      });
+    }
 
-      // Only set link in the last message
-      if (i == currMessages.length - 1) {
-        data.linkTitle = localized(content.linkTitle);
-        data.linkUrl = localized(content.linkUrl);
+    for (i = 0; i < messages.length; i++) {
+      if (typeof messages[i] === 'object') {
+        data = messages[i];
+      }
+      else if (typeof messages[i] === 'string') {
+        data = {
+          message: messages[i].trim(),
+        };
+
+        // Only set link in the last message
+        if (i == messages.length - 1) {
+          data.linkTitle = localized(content.linkTitle);
+          data.linkUrl = localized(content.linkUrl);
+        }
       }
 
       // Render the template and add the message to the screen
@@ -302,7 +313,7 @@
    * Logic to run once the end of the messaging flow has been reached.
    */
   function onMessagesFinished() {
-    $('#container-messages').addClass('-done');
+
   }
 
 })();

--- a/js/dailyshine.js
+++ b/js/dailyshine.js
@@ -14,6 +14,9 @@
   // Queue for storing up messages to display
   var MESSAGE_QUEUE = [];
 
+  // Message counter
+  var messageCounter = 1;
+
   $(document).ready(function() {
     loadDailyShine();
   });
@@ -74,6 +77,9 @@ var date = new Date('2016-08-26T12:00');
     if (nextMessages && nextMessages.length > 0) {
       loadMOChoices(nextMessages);
     }
+    else {
+      onMessagesFinished();
+    }
   }
 
   /**
@@ -110,16 +116,17 @@ var date = new Date('2016-08-26T12:00');
 
     data = {
       label: localized(content.label),
+      messageNum: messageCounter,
     };
 
     html = ejs.render(template, data, {delimiter: '?'});
-    element = $('#container-messages').append(html);
-    element.children(':last')
+    $('#container-messages').append(html)
+        .children(':last')
         .hide()
         .delay(DELAY_MT_DISPLAY + DELAY_MO_DISPLAY)
         .fadeIn(DISPLAY_ANIM_DURATION);
 
-    element.click(onClickMOChoice);
+    $('#mo-' + messageCounter).on('click', onClickMOChoice);
 
     // Add the contents of this message to the queue. When the user clicks on
     // the choice, it can then display the content it finds in the queue.
@@ -130,8 +137,14 @@ var date = new Date('2016-08-26T12:00');
    * Callback when an MO choice is clicked.
    */
   function onClickMOChoice() {
+    var element = $(this);
+
     // @todo Trigger any animation that should happen here before displaying
     // the next message
+    element.removeClass('mo-choice');
+    element.addClass('mo');
+    element.off('click');
+
     displayNextMessage();
   }
 
@@ -140,6 +153,8 @@ var date = new Date('2016-08-26T12:00');
    */
   function displayNextMessage() {
     if (MESSAGE_QUEUE.length > 0) {
+      messageCounter++;
+
       var content = MESSAGE_QUEUE.shift();
       displayMT(content);
     }
@@ -159,6 +174,13 @@ var date = new Date('2016-08-26T12:00');
     else {
       return obj;
     }
+  }
+
+  /**
+   * Logic to run once the end of the messaging flow has been reached.
+   */
+  function onMessagesFinished() {
+    $('#container-messages').addClass('-done');
   }
 
 })();

--- a/js/dailyshine.js
+++ b/js/dailyshine.js
@@ -1,0 +1,164 @@
+'use strict';
+
+(function() {
+
+  // Delay before showing an MT message
+  var DELAY_MT_DISPLAY = 500;
+
+  // Delay before showing the MO options
+  var DELAY_MO_DISPLAY = 1000;
+
+  // Duration of display animations
+  var DISPLAY_ANIM_DURATION = 750;
+
+  // Queue for storing up messages to display
+  var MESSAGE_QUEUE = [];
+
+  $(document).ready(function() {
+    loadDailyShine();
+  });
+
+  /**
+   * Fetches and displays the start of the Daily Shine content.
+   */
+  function loadDailyShine() {
+    // Use the current date to find the corresponding content file
+    // var date = new Date();
+var date = new Date('2016-08-26T12:00');
+    var year = date.getFullYear();
+    var month = date.getMonth() + 1 >= 10 ? date.getMonth() + 1 : '0' + (date.getMonth() + 1);
+    var day = date.getDate() >= 10 ? date.getDate() : '0' + date.getDate();
+    var filename = year + '-' + month + '-' + day;
+    var url = contentBaseUrl + 'dailyshine/' + filename + '.json';
+
+    // Fetch the Daily Shine data and display the starter message.
+    $.get({
+      url: url,
+      data: null,
+      success: function(data) {
+        displayMT(data.starterMessage['en-US'].fields);
+      },
+      dataType: 'json',
+    });
+  }
+
+  /**
+   * Displays content as an MT message.
+   *
+   * @param content Content of the message to display
+   */
+  function displayMT(content) {
+    var data;
+    var html;
+    var template;
+    var nextMessages;
+
+    template = $('#template-mt').html();
+
+    data = {
+      message: localized(content.body),
+      linkTitle: localized(content.linkTitle),
+      linkUrl: localized(content.linkUrl),
+    };
+
+    // Render the template and add the message to the screen
+    html = ejs.render(template, data, {delimiter: '?'});
+    $('#container-messages').append(html)
+        .children(':last')
+        .hide()
+        .delay(DELAY_MT_DISPLAY)
+        .fadeIn(DISPLAY_ANIM_DURATION);
+
+    // Fetch MO options to show the user, if any
+    var nextMessages = localized(content.nextMessages);
+    if (nextMessages && nextMessages.length > 0) {
+      loadMOChoices(nextMessages);
+    }
+  }
+
+  /**
+   * Fetch and display the MO choices for the user.
+   */
+  function loadMOChoices(messages) {
+    // @todo For now, just handling one MO option to display
+    var id = messages[0].sys.id;
+    var url = contentBaseUrl + 'messages/' + id + '.json';
+
+    $.get({
+      url: url,
+      data: null,
+      success: function(data) {
+        displayMOChoices(data);
+      },
+      dataType: 'json',
+    });
+  }
+
+  /**
+   * Displays the MO options for the user to choose from.
+   *
+   * @param content Message content obj. Inludes the `label` property that
+   *                defines what the choices should be.
+   */
+  function displayMOChoices(content) {
+    var data;
+    var element;
+    var html
+    var template;
+
+    template = $('#template-mo-choice').html();
+
+    data = {
+      label: localized(content.label),
+    };
+
+    html = ejs.render(template, data, {delimiter: '?'});
+    element = $('#container-messages').append(html);
+    element.children(':last')
+        .hide()
+        .delay(DELAY_MT_DISPLAY + DELAY_MO_DISPLAY)
+        .fadeIn(DISPLAY_ANIM_DURATION);
+
+    element.click(onClickMOChoice);
+
+    // Add the contents of this message to the queue. When the user clicks on
+    // the choice, it can then display the content it finds in the queue.
+    MESSAGE_QUEUE.push(content);
+  }
+
+  /**
+   * Callback when an MO choice is clicked.
+   */
+  function onClickMOChoice() {
+    // @todo Trigger any animation that should happen here before displaying
+    // the next message
+    displayNextMessage();
+  }
+
+  /**
+   * Displays the next message in the queue.
+   */
+  function displayNextMessage() {
+    if (MESSAGE_QUEUE.length > 0) {
+      var content = MESSAGE_QUEUE.shift();
+      displayMT(content);
+    }
+  }
+
+  /**
+   * Helper function to deal with some content objects that have a property
+   * specifying the 'en-US' locale.
+   *
+   * @param obj
+   * @return The contents of obj, sans 'en-US'
+   */
+  function localized(obj) {
+    if (obj && obj['en-US']) {
+      return obj['en-US'];
+    }
+    else {
+      return obj;
+    }
+  }
+
+})();

--- a/js/dailyshine.js
+++ b/js/dailyshine.js
@@ -3,21 +3,16 @@
 (function() {
 
   // Delay before showing an MT message
-  var DELAY_MT_DISPLAY = 500;
+  var DELAY_MT_DISPLAY = 450;
 
   // Delay before showing the MO options
-  var DELAY_MO_DISPLAY = 500;
+  var DELAY_MO_DISPLAY = 450;
 
   // Duration of display animations
   var DISPLAY_ANIM_DURATION = 750;
 
   // Duration of the viewport scroll animation
   var SCROLL_ANIM_DURATION = 1000;
-
-  // A bucket of random messages someone could receive at the end
-  var END_MESSAGES = [
-    'Some randomized copy can go here #ShineOn 🌟',
-  ];
 
   // Queue for storing up messages to display
   var MESSAGE_QUEUE = [];
@@ -171,12 +166,13 @@
     }
 
     // Fetch MO options to show the user, if any
+    var displayDelay = DELAY_MT_DISPLAY * messages.length;
     var nextMessages = localized(content.nextMessages);
     if (nextMessages && nextMessages.length > 0) {
-      loadMOChoices(nextMessages, DELAY_MT_DISPLAY * messages.length);
+      loadMOChoices(nextMessages, displayDelay);
     }
     else if (! content.intro) {
-      onMessagesFinished();
+      onMessagesFinished(displayDelay);
     }
   }
 
@@ -348,12 +344,13 @@
 
   /**
    * Logic to run once the end of the messaging flow has been reached.
+   *
+   * @param displayDelay
    */
-  function onMessagesFinished() {
+  function onMessagesFinished(displayDelay) {
     var data;
     var date;
     var dateQuery;
-    var element;
     var endMessage;
     var html;
     var template;
@@ -380,16 +377,14 @@
     data = {
       // Used for the share link
       shareLink: 'http://' + window.location.hostname + '?date=' + dateQuery,
-      showCTA: getParameter('r') ? false : true,
-      // Randomly select an end message
-      endMessage: END_MESSAGES[Math.floor(Math.random() * END_MESSAGES.length)],
+      showSignUp: getParameter('r') ? false : true,
     };
 
     html = ejs.render(template, data, {delimiter: '?'});
-    element = $('#container-messages').append(html).children(':last');
-    element.hide()
-        .delay(DELAY_MT_DISPLAY + DELAY_MO_DISPLAY)
-        .fadeIn(DISPLAY_ANIM_DURATION);
+    $('#end-section')
+      .append(html)
+      .delay(displayDelay + DELAY_MO_DISPLAY)
+      .fadeIn(DISPLAY_ANIM_DURATION);
 
     // Send GA event
     if (ga) {

--- a/js/dailyshine.js
+++ b/js/dailyshine.js
@@ -114,8 +114,8 @@
     var template;
     var i;
 
-    // Merge user data into the message
-    body = mergeData(localized(content.body));
+    // Merge user data into the message and turn URLs into links
+    body = makeLinks(mergeData(localized(content.body)));
 
     // Split message by new line so each message gets its own bubble
     messages = body.split('\n');
@@ -285,6 +285,35 @@
     else {
       return obj;
     }
+  }
+
+  /**
+   * Search for URLs in a body of text and convert them to links.
+   *
+   * @param text
+   * @return string
+   */
+  function makeLinks(text) {
+    var match, matches;
+    var startAnchor, endAnchor;
+    var preUrl, postUrl;
+    var i;
+    var regex = /(^|\s)((https?:\/\/)?[\w-]+(\.[\w-]+)+\.?(:\d+)?(\/\S*)?)/gi;
+
+    matches = text.match(regex);
+    for (i = 0; matches && i < matches.length; i++) {
+      match = matches[0].trim();
+      if (match.indexOf('http') >= 0 && text.indexOf(match) >= 0) {
+        startAnchor = '<a href="' + match + '" target="_blank">';
+        endAnchor = '</a>';
+        preUrl = text.substr(0, text.indexOf(match));
+        postUrl = text.substr(text.indexOf(match) + match.length);
+
+        text = preUrl + startAnchor + match + endAnchor + postUrl;
+      }
+    }
+
+    return text;
   }
 
   /**

--- a/styles/dailyshine/colors.less
+++ b/styles/dailyshine/colors.less
@@ -1,7 +1,9 @@
-@color-background: white;
-@color-mo-bg-start: #0084FF;
-@color-mo-bg-end: #0078E5;
-@color-mo-text: white;
-@color-mt-bg: #F0F0F0;
-@color-mt-text: black;
 @color-yellow: #FFCC45;
+
+@color-background: white;
+@color-mo-bg-start: @color-yellow;
+@color-mo-bg-end: black;
+@color-mo-text-start: #242424;
+@color-mo-text-end: white;
+@color-mt-bg: #F3F2F6;
+@color-mt-text: #242424;

--- a/styles/dailyshine/colors.less
+++ b/styles/dailyshine/colors.less
@@ -1,7 +1,7 @@
 @color-background: white;
-@color-mo-bg-start: #9957C5;
-@color-mo-bg-end: #C49BDB;
+@color-mo-bg-start: #0084FF;
+@color-mo-bg-end: #0078E5;
 @color-mo-text: white;
-@color-mt-bg: #FCFCFC;
+@color-mt-bg: #F0F0F0;
 @color-mt-text: black;
 @color-yellow: #FFCC45;

--- a/styles/dailyshine/colors.less
+++ b/styles/dailyshine/colors.less
@@ -1,0 +1,7 @@
+@color-background: white;
+@color-mt-bubble: #FCFCFC;
+@color-mt-text: #DEDEDE;
+@color-mo-bg-start: #C49BDB;
+@color-mo-bg-end: #9957C5
+@color-mo-text: white;
+@color-yellow: #FFCC45;

--- a/styles/dailyshine/colors.less
+++ b/styles/dailyshine/colors.less
@@ -1,7 +1,7 @@
 @color-background: white;
-@color-mt-bubble: #FCFCFC;
-@color-mt-text: #DEDEDE;
-@color-mo-bg-start: #C49BDB;
-@color-mo-bg-end: #9957C5
+@color-mo-bg-start: #9957C5;
+@color-mo-bg-end: #C49BDB;
 @color-mo-text: white;
+@color-mt-bg: #FCFCFC;
+@color-mt-text: black;
 @color-yellow: #FFCC45;

--- a/styles/dailyshine/importer.less
+++ b/styles/dailyshine/importer.less
@@ -1,0 +1,2 @@
+@import 'colors.less';
+@import 'styles.less';

--- a/styles/dailyshine/styles.less
+++ b/styles/dailyshine/styles.less
@@ -1,20 +1,69 @@
-body {
-  background: @color-background;
+body, html {
+  height: 100%;
+  width: 100%;
+  margin: 0;
+  padding: 0;
 }
 
-#container-main {
+body {
+  background: @color-background;
+  font-family: 'Karla';
+  font-weight: 400;
+}
+
+#background {
   background: linear-gradient(135deg, red, @color-yellow);
-  bottom: 0;
-  left: 0;
-  position: absolute;
-  right: 0;
-  top: 0;
+  position: fixed;
+  height: 100%;
+  width: 100%;
+  z-index: -1;
 }
 
 #container-messages {
   bottom: 40px;
   max-width: 400px;
-  padding-left: 10px;
-  padding-right: 10px;
+  padding-left: 20px;
+  padding-right: 20px;
   position: absolute;
+}
+
+#container-messages.-done {
+  position: inherit;
+}
+
+.message-bubble {
+  border-radius: 20px;
+  padding: 10px 20px;
+  margin: 10px 0;
+}
+
+.mt {
+  background: @color-mt-bg;
+  color: @color-mt-text;
+}
+
+.mo {
+  background: linear-gradient(0deg, @color-mo-bg-start, @color-mo-bg-end);
+  color: @color-mo-text;
+  display: inline-block;
+  margin-bottom: 20px;
+  margin-top: 0;
+}
+
+.mo-container {
+  text-align: right;
+}
+
+.mo-choice {
+  background: @color-mo-bg-start;
+  border-radius: 6px;
+  color: @color-mo-text;
+  cursor: pointer;
+  display: inline-block;
+  margin-bottom: 0;
+  margin-top: 20px;
+}
+
+.mo-choice:hover {
+  background: @color-mo-bg-end;
 }

--- a/styles/dailyshine/styles.less
+++ b/styles/dailyshine/styles.less
@@ -37,14 +37,11 @@ html {
   line-height: 24px;
   margin: 4px 0;
   padding: 14px;
-
-  img {
-    max-width: 100%;
-  }
 }
 
 .message-bubble.mt-media {
   padding: 0;
+  max-width: 100%;
 }
 
 .mt {
@@ -64,7 +61,7 @@ html {
   cursor: pointer;
   display: inline-block;
   margin: 8px 0;
-  transform: translate3d(-80px, 20px, 0);
+  transform: translate3d(-60px, 20px, 0);
 
   transition-property: background, color, border-radius, transform;
   transition-duration: 0.3s;
@@ -91,10 +88,58 @@ html {
  * Section that pops up when you make it to the end.
  */
 #end-section {
+  display: none;
+
+  background: black;
+  color: white;
+  font-size: 18px;
+  padding: 40px;
   text-align: center;
 
-  .separator {
-    border-top: 2px dotted white;
+  a {
+    color: @color-yellow;
+  }
+
+  h2 {
+    font-size: 36px;
+    font-weight: 400;
+    margin-top: 10px;
+  }
+
+  .icon-spark {
+    height: 44px;
+    width: 100px;
+    background-image: url("https://images.contentful.com/awpxl2koull4/5ZKJlL0ngAKYYuIGeAQSaY/4614389cb5a621921ea7f8432f2247b9/icon-spark.png?w=100&h=44");
+    background-repeat: no-repeat;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .signup-button {
+    background: @color-yellow;
+    border-radius: 5px;
+    color: black;
     margin: 40px;
+    padding-bottom: 10px;
+    padding-top: 10px;
+    text-transform: uppercase;
+    max-width: 300px;
+  }
+
+  .social-icon {
+    display: inline-block;
+    margin: 10px 20px;
+    height: 50px;
+    width: 50px;
+  }
+
+  .social-icon.-facebook {
+    background-image: url("https://images.contentful.com/awpxl2koull4/2nYxAzNnxes424wIumOwIe/f05b3327fecb2d1673e98b7acef9e9a7/facebook-yellow.png?w=50&h=50");
+    background-repeat: no-repeat;
+  }
+
+  .social-icon.-twitter {
+    background-image: url("https://images.contentful.com/awpxl2koull4/51rBoDXvyg2wQMmW2yASWO/673125cfa07b6b762ff99e5b69f00586/twitter-yellow.png?w=50&h=50");
+    background-repeat: no-repeat;
   }
 }

--- a/styles/dailyshine/styles.less
+++ b/styles/dailyshine/styles.less
@@ -62,7 +62,7 @@ html {
 
 .message-bubble.mt-link {
   background: @color-mt-bg;
-  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
   color: @color-mt-text;
   max-width: 300px;
   padding: 0;
@@ -112,7 +112,7 @@ html {
   cursor: pointer;
   display: inline-block;
   margin: 8px 0;
-  transform: translate3d(0, 20px, 0);
+  transform: translate3d(0, 30px, 0);
 
   transition-property: background, color, border-radius, transform;
   transition-duration: 0.3s;
@@ -144,7 +144,7 @@ html {
   background: black;
   color: white;
   font-size: 18px;
-  padding: 40px;
+  padding: 10px 40px 40px 40px;
   text-align: center;
 
   a {
@@ -155,6 +155,18 @@ html {
     font-size: 36px;
     font-weight: 400;
     margin-top: 10px;
+  }
+
+  .end-arrow {
+    border-radius: 50px;
+    display: inline-block;
+    height: 50px;
+    width: 50px;
+    background-image: url("https://images.contentful.com/awpxl2koull4/67EwXNcqnm6uI8ECcOkW82/25606df2cd74bd095a35f247c4461778/dailyshine-link-arrow.png?w=50&h=50");
+    background-repeat: no-repeat;
+    position: relative;
+    top: -35px;
+    transform: rotate(90deg);
   }
 
   .icon-spark {

--- a/styles/dailyshine/styles.less
+++ b/styles/dailyshine/styles.less
@@ -20,8 +20,12 @@ html {
   background-size: cover;
 }
 
+/**
+ * Main message container.
+ */
 #container-messages {
   bottom: 40px;
+  margin: 0 auto;
   max-width: 400px;
   padding: 40px 20px;
 }
@@ -32,7 +36,7 @@ html {
   font-size: 16px;
   line-height: 22px;
   margin: 2px 0;
-  padding: 10px 20px;
+  padding: 10px;
 
   img {
     max-width: 100%;
@@ -49,7 +53,7 @@ html {
   color: @color-mo-text;
   display: inline-block;
   margin-bottom: 20px;
-  margin-top: 0;
+  margin-top: 10px;
 }
 
 .mo-container {
@@ -68,4 +72,16 @@ html {
 
 .mo-choice:hover {
   background: @color-mo-bg-end;
+}
+
+/**
+ * Section that pops up when you make it to the end.
+ */
+#end-section {
+  text-align: center;
+
+  .separator {
+    border-top: 2px dotted white;
+    margin: 40px;
+  }
 }

--- a/styles/dailyshine/styles.less
+++ b/styles/dailyshine/styles.less
@@ -6,6 +6,7 @@ body, html {
 }
 
 body {
+  border-top: 4px solid @color-yellow;
   font-family: 'Karla';
   font-weight: 400;
 }
@@ -27,7 +28,20 @@ html {
   bottom: 40px;
   margin: 0 auto;
   max-width: 400px;
-  padding: 40px 20px;
+  padding: 20px 20px 40px 20px;
+}
+
+.link-arrow {
+  border-radius: 40px;
+  height: 40px;
+  width: 40px;
+  background-image: url("https://images.contentful.com/awpxl2koull4/67EwXNcqnm6uI8ECcOkW82/25606df2cd74bd095a35f247c4461778/dailyshine-link-arrow.png?w=40&h=40");
+  background-repeat: no-repeat;
+  box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
+}
+
+.link-arrow:hover {
+  box-shadow: none;
 }
 
 .message-bubble {
@@ -42,6 +56,33 @@ html {
 .message-bubble.mt-media {
   padding: 0;
   max-width: 100%;
+}
+
+.message-bubble.mt-link {
+  background: @color-mt-bg;
+  color: @color-mt-text;
+  max-width: 300px;
+  padding: 0;
+
+  .container-msg {
+    padding: 14px;
+  }
+
+  .container-link {
+    background: @color-yellow;
+    border-bottom-left-radius: 8px;
+    border-bottom-right-radius: 8px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+    color: @color-mt-text;
+    display: block;
+    padding: 8px;
+    text-align: center;
+    text-decoration: none;
+  }
+
+  .container-link:hover {
+    box-shadow: none;
+  }
 }
 
 .mt {
@@ -61,7 +102,7 @@ html {
   cursor: pointer;
   display: inline-block;
   margin: 8px 0;
-  transform: translate3d(-60px, 20px, 0);
+  transform: translate3d(0, 20px, 0);
 
   transition-property: background, color, border-radius, transform;
   transition-duration: 0.3s;
@@ -119,7 +160,7 @@ html {
     background: @color-yellow;
     border-radius: 5px;
     color: black;
-    margin: 40px;
+    margin: 40px auto;
     padding-bottom: 10px;
     padding-top: 10px;
     text-transform: uppercase;

--- a/styles/dailyshine/styles.less
+++ b/styles/dailyshine/styles.less
@@ -1,0 +1,20 @@
+body {
+  background: @color-background;
+}
+
+#container-main {
+  background: linear-gradient(135deg, red, @color-yellow);
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+#container-messages {
+  bottom: 40px;
+  max-width: 400px;
+  padding-left: 10px;
+  padding-right: 10px;
+  position: absolute;
+}

--- a/styles/dailyshine/styles.less
+++ b/styles/dailyshine/styles.less
@@ -11,7 +11,7 @@ body {
 }
 
 html {
-  background: url('https://image.freepik.com/free-vector/tricolor-gradient-background_1095-64.jpg') fixed;
+  /*background: url('some image here if we want to eventually add a background') fixed;*/
   background-position: center;
   background-repeat: no-repeat;
   -webkit-background-size: cover;
@@ -33,27 +33,24 @@ html {
 .message-bubble {
   border-radius: 8px;
   display: inline-block;
-  font-size: 16px;
-  line-height: 22px;
-  margin: 2px 0;
-  padding: 10px;
+  font-size: 18px;
+  line-height: 24px;
+  margin: 4px 0;
+  padding: 14px;
 
   img {
     max-width: 100%;
   }
 }
 
+.message-bubble.mt-media {
+  padding: 0;
+}
+
 .mt {
   background: @color-mt-bg;
   color: @color-mt-text;
-}
-
-.mo {
-  background: linear-gradient(0deg, @color-mo-bg-start, @color-mo-bg-end);
-  color: @color-mo-text;
-  display: inline-block;
-  margin-bottom: 20px;
-  margin-top: 10px;
+  max-width: 300px;
 }
 
 .mo-container {
@@ -62,16 +59,32 @@ html {
 
 .mo-choice {
   background: @color-mo-bg-start;
-  border-radius: 6px;
-  color: @color-mo-text;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.5);
+  color: @color-mo-text-start;
   cursor: pointer;
   display: inline-block;
-  margin-bottom: 0;
-  margin-top: 20px;
+  margin: 8px 0;
+  transform: translate3d(-80px, 20px, 0);
+
+  transition-property: background, color, border-radius, transform;
+  transition-duration: 0.3s;
+  transition-timing-function: ease-in-out;
 }
 
 .mo-choice:hover {
+  box-shadow: none;
+}
+
+.mo-choice.-clicked {
   background: @color-mo-bg-end;
+  color: @color-mo-text-end;
+  cursor: default;
+  border-top-left-radius: 20px;
+  border-top-right-radius: 20px;
+  border-bottom-right-radius: 2px;
+  border-bottom-left-radius: 20px;
+  box-shadow: none;
+  transform: translate3d(0, 0, 0);
 }
 
 /**

--- a/styles/dailyshine/styles.less
+++ b/styles/dailyshine/styles.less
@@ -6,35 +6,37 @@ body, html {
 }
 
 body {
-  background: @color-background;
   font-family: 'Karla';
   font-weight: 400;
 }
 
-#background {
-  background: linear-gradient(135deg, red, @color-yellow);
-  position: fixed;
-  height: 100%;
-  width: 100%;
-  z-index: -1;
+html {
+  background: url('https://image.freepik.com/free-vector/tricolor-gradient-background_1095-64.jpg') fixed;
+  background-position: center;
+  background-repeat: no-repeat;
+  -webkit-background-size: cover;
+  -moz-background-size: cover;
+  -o-background-size: cover;
+  background-size: cover;
 }
 
 #container-messages {
   bottom: 40px;
   max-width: 400px;
-  padding-left: 20px;
-  padding-right: 20px;
-  position: absolute;
-}
-
-#container-messages.-done {
-  position: inherit;
+  padding: 40px 20px;
 }
 
 .message-bubble {
-  border-radius: 20px;
+  border-radius: 8px;
+  display: inline-block;
+  font-size: 16px;
+  line-height: 22px;
+  margin: 2px 0;
   padding: 10px 20px;
-  margin: 10px 0;
+
+  img {
+    max-width: 100%;
+  }
 }
 
 .mt {

--- a/styles/dailyshine/styles.less
+++ b/styles/dailyshine/styles.less
@@ -32,12 +32,14 @@ html {
 }
 
 .link-arrow {
-  border-radius: 40px;
-  height: 40px;
-  width: 40px;
-  background-image: url("https://images.contentful.com/awpxl2koull4/67EwXNcqnm6uI8ECcOkW82/25606df2cd74bd095a35f247c4461778/dailyshine-link-arrow.png?w=40&h=40");
+  border-radius: 28px;
+  display: inline-block;
+  height: 28px;
+  width: 28px;
+  background-image: url("https://images.contentful.com/awpxl2koull4/67EwXNcqnm6uI8ECcOkW82/25606df2cd74bd095a35f247c4461778/dailyshine-link-arrow.png?w=28&h=28");
   background-repeat: no-repeat;
-  box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
+  position: relative;
+  top: 7px;
 }
 
 .link-arrow:hover {
@@ -60,29 +62,37 @@ html {
 
 .message-bubble.mt-link {
   background: @color-mt-bg;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.5);
   color: @color-mt-text;
   max-width: 300px;
   padding: 0;
+  text-decoration: none;
 
   .container-msg {
     padding: 14px;
   }
 
   .container-link {
-    background: @color-yellow;
+    background: @color-mt-bg;
     border-bottom-left-radius: 8px;
     border-bottom-right-radius: 8px;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
     color: @color-mt-text;
     display: block;
-    padding: 8px;
-    text-align: center;
-    text-decoration: none;
+    padding: 0 8px 14px 8px;
+
+    .link-message {
+      display: inline-block;
+      padding-left: 8px;
+    }
   }
 
   .container-link:hover {
     box-shadow: none;
   }
+}
+
+.message-bubble.mt-link:hover {
+  box-shadow: none;
 }
 
 .mt {

--- a/styles/variables/fonts.less
+++ b/styles/variables/fonts.less
@@ -80,6 +80,6 @@
 @font-size-featured-subtitle-xs: 20px;
 @font-size-featured-normal-xs: 16px;
 
-@font-size-homepage-normal: 24px;
+@font-size-homepage-normal: 22px;
 @font-size-homepage-normal-xs: 20px;
 @font-size-homepage-testimonial-credit: 20px;

--- a/templates/daily-shine.ejs
+++ b/templates/daily-shine.ejs
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Today's Shine</title>
+
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+
+  <link href="https://fonts.googleapis.com/css?family=Caveat+Brush" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css?family=Karla:400,400i,700" rel="stylesheet" type="text/css">
+
+  <link href="<%= css %>" rel="stylesheet">
+
+</head>
+<body>
+
+  <div id="container-main">
+    <div id="container-messages">
+      hi.
+    </div>
+  </div>
+
+  <!-- Content templates -->
+  <!-- Template for messages that are sent to the user. -->
+  <script id="template-mt" type="text/template">
+    <div class="container-mt">
+      <?= message ?>
+      <? if (linkTitle && linkUrl) { ?>
+      <div>
+        <a href="<?= linkUrl ?>" target="_blank"><?= linkTitle ?></a>
+      </div>
+      <? } ?>
+    </div>
+  </script>
+
+  <!-- Template for messages that are sent from the users. -->
+  <script id="template-mo" type="text/template">
+    <div class="container-mo">
+    </div>
+  </script>
+
+  <!-- Template for button choices the user can tap to respond with. -->
+  <script id="template-mo-choice" type="text/template">
+    <div class="container-mo-choice">
+    <?= label ?>
+    </div>
+  </script>
+
+  <!-- JS -->
+  <script src="https://code.jquery.com/jquery-2.2.4.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous"></script>
+
+  <script>
+  var contentBaseUrl = '<%= contentBaseUrl %>';
+  </script>
+  <script src="<% if (typeof jsPath !== 'undefined') { %><%= jsPath %><% } %>/js/ejs.min.js"></script>
+  <script src="<% if (typeof jsPath !== 'undefined') { %><%= jsPath %><% } %>/js/dailyshine.js"></script>
+</body>
+</html>

--- a/templates/daily-shine.ejs
+++ b/templates/daily-shine.ejs
@@ -43,16 +43,15 @@
 
   <!-- Template for messages with links. -->
   <script id="template-mt-link" type="text/template">
-    <div>
-      <div class="message-bubble mt-link">
-        <div class="container-msg">
-          <?= message ?>
-        </div>
-        <a class="container-link" href="<?= linkUrl ?>" target="_blank">
-          <?= linkTitle ?>
-        </a>
+    <a class="message-bubble mt-link" href="<?= linkUrl ?>" target="_blank">
+      <div class="container-msg">
+        <?= message ?>
       </div>
-    </div>
+      <div class="container-link">
+        <div class="link-arrow"></div>
+        <div class="link-message"><?= linkTitle ?></div>
+      </div>
+    </a>
   </script>
 
   <!-- Template for messages with media sent to the user. -->

--- a/templates/daily-shine.ejs
+++ b/templates/daily-shine.ejs
@@ -24,19 +24,15 @@
 <body>
 
   <div>
-    <div id="container-messages">
-      <div class="mt message-bubble">hi.</div>
-    </div>
+    <div id="container-messages"></div>
   </div>
 
   <!-- Content templates -->
+
   <!-- Template for messages that are sent to the user. -->
   <script id="template-mt" type="text/template">
     <div>
       <div class="mt message-bubble">
-        <? if (typeof media !== 'undefined') { ?>
-          <img src="https://<?= media ?>?w=400">
-        <? } ?>
         <? if (typeof message !== 'undefined') { ?>
           <?= message ?>
         <? } ?>
@@ -49,10 +45,9 @@
     </div>
   </script>
 
-  <!-- Template for messages that are sent from the users. -->
-  <script id="template-mo" type="text/template">
-    <div class="mo message-bubble">
-    </div>
+  <!-- Template for messages with media sent to the user. -->
+  <script id="template-mt-media" type="text/template">
+    <img class="message-bubble mt-media" src="https://<?= media ?>?w=400">
   </script>
 
   <!-- Template for button choices the user can tap to respond with. -->

--- a/templates/daily-shine.ejs
+++ b/templates/daily-shine.ejs
@@ -25,6 +25,7 @@
 
   <div>
     <div id="container-messages"></div>
+    <div id="end-section"></div>
   </div>
 
   <!-- Content templates -->
@@ -64,23 +65,22 @@
 
   <!-- Template for section that's displayed once the end is reached -->
   <script id="template-daily-end" type="text/template">
-    <div id="end-section">
-      <div class="separator"></div>
-      <? if (showCTA) { ?>
-        <div>Like what you read?</div>
-        <div>Get Shine now for daily affirmations on your phone!</div>
-        <div>
-          <a href="http://www.shinetext.com">SIGN UP</a>
-        </div>
-      <? } ?>
-      <div id="end-message"><?= endMessage ?></div>
-      <div>Share Today's Shine with friends!</div>
-      <a href="<?= shareLink ?>">
-        <?= shareLink ?>
-      </a>
-      <div>Facebook</div>
-      <div>Twitter</div>
-    </div>
+    <div class="icon-spark"></div>
+  <? if (showSignUp) { ?>
+    <h2>Get Shine!</h2>
+    <p>🌟 Like what you read? 🌟</p>
+    <p>Get Shine now for daily affirmations on your phone!</p>
+    <a href="http://www.shinetext.com"><div class="signup-button">SIGN UP</div></a>
+  <? } else { ?>
+    <h2>Pass On the Shine!</h2>
+    <p>Share the good feels with your bffs 😻 with the link below.</p>
+    <a href="<?= shareLink ?>">
+      <?= shareLink ?>
+    </a>
+    <p>or share on</p>
+    <a class="social-icon -facebook" href="http://www.facebook.com/sharer/sharer.php?u=<?= shareLink ?>" target="_blank"></a>
+    <a class="social-icon -twitter" href="http://twitter.com/share?url=<?= shareLink ?>&text=Today's Shine from @ShineText!" target="_blank"></a>
+  <? } ?>
   </script>
 
   <!-- JS -->

--- a/templates/daily-shine.ejs
+++ b/templates/daily-shine.ejs
@@ -13,8 +13,10 @@
 </head>
 <body>
 
-  <div id="container-messages">
-    <div class="mt message-bubble">hi.</div>
+  <div>
+    <div id="container-messages">
+      <div class="mt message-bubble">hi.</div>
+    </div>
   </div>
 
   <!-- Content templates -->
@@ -49,6 +51,27 @@
       <div id="mo-<?= messageNum ?>" class="mo-choice message-bubble">
       <?= label ?>
       </div>
+    </div>
+  </script>
+
+  <!-- Template for section that's displayed once the end is reached -->
+  <script id="template-daily-end" type="text/template">
+    <div id="end-section">
+      <div class="separator"></div>
+      <? if (showCTA) { ?>
+        <div>Like what you read?</div>
+        <div>Get Shine now for daily affirmations on your phone!</div>
+        <div>
+          <a href="http://www.shinetext.com">SIGN UP</a>
+        </div>
+      <? } ?>
+      <div id="end-message"><?= endMessage ?></div>
+      <div>Share Today's Shine with friends!</div>
+      <a href="<?= shareLink ?>">
+        <?= shareLink ?>
+      </a>
+      <div>Facebook</div>
+      <div>Twitter</div>
     </div>
   </script>
 

--- a/templates/daily-shine.ejs
+++ b/templates/daily-shine.ejs
@@ -14,16 +14,15 @@
 </head>
 <body>
 
-  <div id="container-main">
-    <div id="container-messages">
-      hi.
-    </div>
+  <div id="background"></div>
+  <div id="container-messages">
+    <div class="mt message-bubble">hi.</div>
   </div>
 
   <!-- Content templates -->
   <!-- Template for messages that are sent to the user. -->
   <script id="template-mt" type="text/template">
-    <div class="container-mt">
+    <div class="mt message-bubble">
       <?= message ?>
       <? if (linkTitle && linkUrl) { ?>
       <div>
@@ -35,14 +34,16 @@
 
   <!-- Template for messages that are sent from the users. -->
   <script id="template-mo" type="text/template">
-    <div class="container-mo">
+    <div class="mo message-bubble">
     </div>
   </script>
 
   <!-- Template for button choices the user can tap to respond with. -->
   <script id="template-mo-choice" type="text/template">
-    <div class="container-mo-choice">
-    <?= label ?>
+    <div class="mo-container">
+      <div id="mo-<?= messageNum ?>" class="mo-choice message-bubble">
+      <?= label ?>
+      </div>
     </div>
   </script>
 

--- a/templates/daily-shine.ejs
+++ b/templates/daily-shine.ejs
@@ -10,6 +10,15 @@
 
   <link href="<%= css %>" rel="stylesheet">
 
+  <script>
+    window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+    ga('create', 'UA-68971267-2', 'auto');
+    ga('require', 'eventTracker');
+    ga('send', 'pageview');
+
+  </script>
+  <script async src='https://www.google-analytics.com/analytics.js'></script>
+  <script async src='https://cdnjs.cloudflare.com/ajax/libs/autotrack/1.0.1/autotrack.js'></script>
 </head>
 <body>
 
@@ -48,7 +57,10 @@
   <!-- Template for button choices the user can tap to respond with. -->
   <script id="template-mo-choice" type="text/template">
     <div class="mo-container">
-      <div id="mo-<?= messageNum ?>" class="mo-choice message-bubble">
+      <div id="mo-<?= messageNum ?>" class="mo-choice message-bubble"
+        ga-on="click"
+        ga-event-category="MO"
+        ga-event-action="click">
       <?= label ?>
       </div>
     </div>

--- a/templates/daily-shine.ejs
+++ b/templates/daily-shine.ejs
@@ -35,7 +35,7 @@
     <div>
       <div class="mt message-bubble">
         <? if (typeof message !== 'undefined') { ?>
-          <?= message ?>
+          <?- message ?>
         <? } ?>
       </div>
     </div>
@@ -45,7 +45,7 @@
   <script id="template-mt-link" type="text/template">
     <a class="message-bubble mt-link" href="<?= linkUrl ?>" target="_blank">
       <div class="container-msg">
-        <?= message ?>
+        <?- message ?>
       </div>
       <div class="container-link">
         <div class="link-arrow"></div>
@@ -73,6 +73,7 @@
 
   <!-- Template for section that's displayed once the end is reached -->
   <script id="template-daily-end" type="text/template">
+    <div class="end-arrow"></div>
     <div class="icon-spark"></div>
   <? if (showSignUp) { ?>
     <h2>Get Shine!</h2>

--- a/templates/daily-shine.ejs
+++ b/templates/daily-shine.ejs
@@ -5,6 +5,7 @@
 
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <meta name="description" content="Today's Shine. Messages with motivational quotes, positive affirmations and actions you can take every morning."
 
   <link href="https://fonts.googleapis.com/css?family=Karla:400,400i,700" rel="stylesheet" type="text/css">
 

--- a/templates/daily-shine.ejs
+++ b/templates/daily-shine.ejs
@@ -52,6 +52,7 @@
 
   <script>
   var contentBaseUrl = '<%= contentBaseUrl %>';
+  var photonBaseUrl = '<%= photonBaseUrl %>';
   </script>
   <script src="<% if (typeof jsPath !== 'undefined') { %><%= jsPath %><% } %>/js/ejs.min.js"></script>
   <script src="<% if (typeof jsPath !== 'undefined') { %><%= jsPath %><% } %>/js/dailyshine.js"></script>

--- a/templates/daily-shine.ejs
+++ b/templates/daily-shine.ejs
@@ -5,7 +5,7 @@
 
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-  <meta name="description" content="Today's Shine. Messages with motivational quotes, positive affirmations and actions you can take every morning."
+  <meta name="description" content="Today's Shine. Messages with motivational quotes, positive affirmations and actions you can take every morning.">
 
   <link href="https://fonts.googleapis.com/css?family=Karla:400,400i,700" rel="stylesheet" type="text/css">
 
@@ -37,11 +37,20 @@
         <? if (typeof message !== 'undefined') { ?>
           <?= message ?>
         <? } ?>
-        <? if (typeof linkTitle !== 'undefined' && typeof linkUrl !== 'undefined') { ?>
-        <div>
-          <a href="<?= linkUrl ?>" target="_blank"><?= linkTitle ?></a>
+      </div>
+    </div>
+  </script>
+
+  <!-- Template for messages with links. -->
+  <script id="template-mt-link" type="text/template">
+    <div>
+      <div class="message-bubble mt-link">
+        <div class="container-msg">
+          <?= message ?>
         </div>
-        <? } ?>
+        <a class="container-link" href="<?= linkUrl ?>" target="_blank">
+          <?= linkTitle ?>
+        </a>
       </div>
     </div>
   </script>

--- a/templates/daily-shine.ejs
+++ b/templates/daily-shine.ejs
@@ -6,7 +6,6 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 
-  <link href="https://fonts.googleapis.com/css?family=Caveat+Brush" rel="stylesheet" type="text/css">
   <link href="https://fonts.googleapis.com/css?family=Karla:400,400i,700" rel="stylesheet" type="text/css">
 
   <link href="<%= css %>" rel="stylesheet">
@@ -14,7 +13,6 @@
 </head>
 <body>
 
-  <div id="background"></div>
   <div id="container-messages">
     <div class="mt message-bubble">hi.</div>
   </div>
@@ -22,13 +20,20 @@
   <!-- Content templates -->
   <!-- Template for messages that are sent to the user. -->
   <script id="template-mt" type="text/template">
-    <div class="mt message-bubble">
-      <?= message ?>
-      <? if (linkTitle && linkUrl) { ?>
-      <div>
-        <a href="<?= linkUrl ?>" target="_blank"><?= linkTitle ?></a>
+    <div>
+      <div class="mt message-bubble">
+        <? if (typeof media !== 'undefined') { ?>
+          <img src="https://<?= media ?>?w=400">
+        <? } ?>
+        <? if (typeof message !== 'undefined') { ?>
+          <?= message ?>
+        <? } ?>
+        <? if (typeof linkTitle !== 'undefined' && typeof linkUrl !== 'undefined') { ?>
+        <div>
+          <a href="<?= linkUrl ?>" target="_blank"><?= linkTitle ?></a>
+        </div>
+        <? } ?>
       </div>
-      <? } ?>
     </div>
   </script>
 


### PR DESCRIPTION
- In conjunction with the [onDailyCreated](https://github.com/shinetext/prism/tree/master/functions/onDailyCreated) webhook, this can bring the daily Shine message to the web.
- Some query params to know about:
  - `r=`: If the value here is set to a user's referral code, it'll be able to query that code for some user info that can be used in the message -- basically just `{{first_name}}` and `{{referral_code}}` right now
  - `date=`: Setting this to a date with the format `MM-dd-YYYY` will show the Shine text for that day
- CircleCI manages the deployment in the same way that it does deploys to our articles content site. (Note: it might make more sense to separate these out into their own projects in order to have separate deployments)
